### PR TITLE
Fixed "new Identifier()" problem in Minecraft 1.21, is "Identifier.of…

### DIFF
--- a/src/main/java/com/minenash/action_hunger/ActionHunger.java
+++ b/src/main/java/com/minenash/action_hunger/ActionHunger.java
@@ -72,7 +72,7 @@ public class ActionHunger implements ModInitializer {
 
 	private void mapHealthEffects() {
 		for (HealthEffect effect : Config.effects)
-			effect.statusEffect = Registries.STATUS_EFFECT.get(new Identifier(effect.effect));
+			effect.statusEffect = Registries.STATUS_EFFECT.get(Identifier.of(effect.effect));
 	}
 
 	public static double getCurveModifier(float stepper, Config.Curve curve, float multiplier) {
@@ -84,4 +84,5 @@ public class ActionHunger implements ModInitializer {
 			case EXPONENTIAL -> Math.pow(Math.E, step);
 		};
 	}
+
 }

--- a/src/main/java/com/minenash/action_hunger/FoodLevelForSprintPacket.java
+++ b/src/main/java/com/minenash/action_hunger/FoodLevelForSprintPacket.java
@@ -7,7 +7,7 @@ import net.minecraft.network.packet.CustomPayload;
 import net.minecraft.util.Identifier;
 
 public record FoodLevelForSprintPacket(int foodLevel) implements CustomPayload {
-    public static final CustomPayload.Id<FoodLevelForSprintPacket> PACKET_ID = new CustomPayload.Id<>(new Identifier("action_hunger", "food_level_for_sprint"));
+    public static final CustomPayload.Id<FoodLevelForSprintPacket> PACKET_ID = new CustomPayload.Id<>(Identifier.of("action_hunger", "food_level_for_sprint"));
     public static final PacketCodec<RegistryByteBuf, FoodLevelForSprintPacket> PACKET_CODEC = PacketCodecs.VAR_INT.xmap(FoodLevelForSprintPacket::new, FoodLevelForSprintPacket::foodLevel).cast();
 
     @Override


### PR DESCRIPTION
…()" and Update to Minecraft 1.21